### PR TITLE
README code sample fix when using Robolectric

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ public class ExampleApplication extends Application {
  
   protected RefWatcher setupLeakCanary() {
     if (LeakCanary.isInAnalyzerProcess(this)) {
-      return;
+      return RefWatcher.DISABLED;
     }
     return LeakCanary.install(this);
   }


### PR DESCRIPTION
`setupLeakCanary()` method that was added for Robolectric test's ability to override setting up LeakCanary wasn't returning any value for the analyzer process check, which does not compile.  Added the `DISABLED` return value for when in the "Analyzer" process is detected.